### PR TITLE
Fix deprecation error in 3.10 when using collections.Sequence

### DIFF
--- a/vix/VixHost.py
+++ b/vix/VixHost.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
 import collections
+try:
+    # warns as of 3.3 and errors in 3.10
+    collections_abc = collections.abc
+except AttributeError:  # python <3.3
+    collections_abc = collections
+
 import platform
 import os
 import os.path
@@ -99,7 +105,7 @@ class VixHost(object):
         assert self._handle == None, 'Instance is already connected.'
 
         if service_provider in (self.VIX_SERVICEPROVIDER_VMWARE_VI_SERVER, self.VIX_SERVICEPROVIDER_VMWARE_WORKSTATION_SHARED):
-            if isinstance(host, collections.Sequence) and len(host) == 2 and host[1] != 0:
+            if isinstance(host, collections_abc.Sequence) and len(host) == 2 and host[1] != 0:
                 host = ('%s:%s' % host, 0)
 
             elif host is None and service_provider == self.VIX_SERVICEPROVIDER_VMWARE_WORKSTATION_SHARED:
@@ -112,7 +118,7 @@ class VixHost(object):
 
                 host = ('localhost:%d' % (int(ElementTree.parse(vmhostd_proxy_xml).getroot().find('httpsPort').text), ), 0)
 
-            assert credentials is not None and isinstance(credentials, collections.Sequence) and len(credentials) == 2 \
+            assert credentials is not None and isinstance(credentials, collections_abc.Sequence) and len(credentials) == 2 \
                    and credentials[0] is not None and credentials[1] is not None, \
                    'Null credentials blocks vix api.'
 
@@ -121,8 +127,8 @@ class VixHost(object):
         if not credentials:
             credentials = (None, None, )
 
-        assert isinstance(host, collections.Sequence) and len(host) == 2, 'Host must be a tuple of size 2'
-        assert isinstance(credentials, collections.Sequence) and len(credentials) == 2, 'Credentials must be a tuple of size 2'
+        assert isinstance(host, collections_abc.Sequence) and len(host) == 2, 'Host must be a tuple of size 2'
+        assert isinstance(credentials, collections_abc.Sequence) and len(credentials) == 2, 'Credentials must be a tuple of size 2'
 
         job = vix.VixHost_Connect(
             self._VIX_API_VERSION,


### PR DESCRIPTION
`collection.Sequence` was deprecated in favor of `collections.abc.Sequence` as of version 3.3 (among the rest of the abstract base classes) and was finally removed in 3.10 - https://docs.python.org/3/whatsnew/3.10.html#removed

Copied solution from https://github.com/chainer/chainer/pull/5172